### PR TITLE
feat: removes serverurl from templates to fallback to relative url

### DIFF
--- a/templates/javascript/payload.config.js
+++ b/templates/javascript/payload.config.js
@@ -3,7 +3,6 @@ import TodoLists from './collections/TodoLists';
 import Users from './collections/Users';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
   admin: {
     user: Users.slug,
   },

--- a/templates/typescript/src/payload.config.ts
+++ b/templates/typescript/src/payload.config.ts
@@ -3,7 +3,6 @@ import TodoLists from './collections/TodoLists';
 import Users from './collections/Users';
 
 export default buildConfig({
-  serverURL: 'http://localhost:3000',
   admin: {
     user: Users.slug,
   },


### PR DESCRIPTION
This needs to go out after 
https://github.com/payloadcms/payload/pull/8