### PR TITLE
fix: workaround for npm install peer dependency on node 16

### DIFF
--- a/utils/createProject.js
+++ b/utils/createProject.js
@@ -25,7 +25,7 @@ const installDeps = async (dir, packageManager) => {
   if (args['--no-deps']) {
     return { failed: false };
   }
-  let cmd = packageManager === 'yarn' ? 'yarn' : 'npm install';
+  let cmd = packageManager === 'yarn' ? 'yarn' : 'npm install --legacy-peer-deps';
 
   let result = false;
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.3.3", "@sentry/tracing@^6.3.3":
+"@sentry/tracing@6.3.3":
   version "6.3.3"
   resolved "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.3.tgz#ae729a4fc1c887df6736435f41d0d4fa446f0d3d"
   integrity sha512-xtiUfgxDnxgcmwVeZiwOwlwSfT0zCCQWVRRUz6YOnuageEkJpJAXqGgpTTkB5tDrmt7E7Ikq5XF4qzQGMGQLWw==


### PR DESCRIPTION
Working locally, tested with npm on node 15.5.0 and 16.0.0.