### PR TITLE
Install packages before copying rest of code in Dockerfile template

### DIFF
--- a/src/lib/common-files/Dockerfile.template
+++ b/src/lib/common-files/Dockerfile.template
@@ -4,9 +4,9 @@ FROM base as builder
 
 WORKDIR /home/node/app
 COPY package*.json ./
+RUN {{installCmd}}
 
 COPY . .
-RUN {{installCmd}}
 RUN {{buildCmd}}
 
 FROM base as runtime


### PR DESCRIPTION
The Dockerfile was copying the `package*.json` files, then copying the entire rest of the code, and _then_ installing the dependencies. This defeats the purpose of copying `package*.json` first, since the build step cache will be invalidated whenever the code changes.

This PR moves the install command above the code copy command.

P.S. I didn't see any contribution guidelines, sorry if this PR does not adhere to a required template.